### PR TITLE
Fix cross domain user error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiter-integration-google",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A JupiterOne managed integration for Google",
   "main": "index.js",
   "repository": "https://github.com/jupiterone/jupiter-integration-google",

--- a/src/converters/AccountEntityConverter.ts
+++ b/src/converters/AccountEntityConverter.ts
@@ -5,12 +5,12 @@ import {
   AccountEntity,
 } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 export function createAccountEntity(account: Account): AccountEntity {
   return {
     _class: ACCOUNT_ENTITY_CLASS,
-    _key: generateKey(ACCOUNT_ENTITY_TYPE, account.id),
+    _key: generateEntityKey(ACCOUNT_ENTITY_TYPE, account.id),
     _type: ACCOUNT_ENTITY_TYPE,
     displayName: account.name,
     name: account.name,

--- a/src/converters/AccountGroupRelationshipConverter.ts
+++ b/src/converters/AccountGroupRelationshipConverter.ts
@@ -8,7 +8,7 @@ import {
   GROUP_ENTITY_TYPE,
 } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 export function createAccountGroupRelationships(
   groups: Group[],
@@ -17,8 +17,8 @@ export function createAccountGroupRelationships(
   const defaultValue: AccountGroupRelationship[] = [];
 
   return groups.reduce((acc, group) => {
-    const parentKey = generateKey(ACCOUNT_ENTITY_TYPE, account.id);
-    const childKey = generateKey(GROUP_ENTITY_TYPE, group.id);
+    const parentKey = generateEntityKey(ACCOUNT_ENTITY_TYPE, account.id);
+    const childKey = generateEntityKey(GROUP_ENTITY_TYPE, group.id);
 
     const relationship: AccountGroupRelationship = {
       _class: ACCOUNT_GROUP_RELATIONSHIP_CLASS,

--- a/src/converters/AccountUserRelationshipConverter.ts
+++ b/src/converters/AccountUserRelationshipConverter.ts
@@ -8,7 +8,7 @@ import {
   USER_ENTITY_TYPE,
 } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 export function createAccountUserRelationships(
   users: User[],
@@ -17,8 +17,8 @@ export function createAccountUserRelationships(
   const defaultValue: AccountUserRelationship[] = [];
 
   return users.reduce((acc, user) => {
-    const parentKey = generateKey(ACCOUNT_ENTITY_TYPE, account.id);
-    const childKey = generateKey(USER_ENTITY_TYPE, user.id);
+    const parentKey = generateEntityKey(ACCOUNT_ENTITY_TYPE, account.id);
+    const childKey = generateEntityKey(USER_ENTITY_TYPE, user.id);
 
     const relationship: AccountUserRelationship = {
       _class: ACCOUNT_USER_RELATIONSHIP_CLASS,

--- a/src/converters/GroupEntityConverter.ts
+++ b/src/converters/GroupEntityConverter.ts
@@ -5,13 +5,13 @@ import {
   GroupEntity,
 } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 export function createGroupEntities(data: Group[]): GroupEntity[] {
   return data.map(group => {
     return {
       _class: GROUP_ENTITY_CLASS,
-      _key: generateKey(GROUP_ENTITY_TYPE, group.id),
+      _key: generateEntityKey(GROUP_ENTITY_TYPE, group.id),
       _type: GROUP_ENTITY_TYPE,
       id: group.id,
       adminCreated: group.adminCreated,

--- a/src/converters/SiteEntityConverter.ts
+++ b/src/converters/SiteEntityConverter.ts
@@ -1,7 +1,7 @@
 import { User } from "../gsuite/GSuiteClient";
 import { SITE_ENTITY_CLASS, SITE_ENTITY_TYPE, SiteEntity } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 export function createSiteEntities(data: User[]): SiteEntity[] {
   const defaultValue: SiteEntity[] = [];
@@ -19,7 +19,7 @@ export function createSiteEntities(data: User[]): SiteEntity[] {
       ].join(", ");
 
       return {
-        _key: generateKey(
+        _key: generateEntityKey(
           SITE_ENTITY_TYPE,
           `${user.id}_${location.buildingId}`,
         ),

--- a/src/converters/SiteUserRelationshipConverter.ts
+++ b/src/converters/SiteUserRelationshipConverter.ts
@@ -8,7 +8,7 @@ import {
   USER_ENTITY_TYPE,
 } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 export function createSiteUserRelationships(users: User[]) {
   const defaultValue: SiteUserRelationship[] = [];
@@ -18,10 +18,10 @@ export function createSiteUserRelationships(users: User[]) {
       return acc;
     }
 
-    const childKey = generateKey(USER_ENTITY_TYPE, user.id);
+    const childKey = generateEntityKey(USER_ENTITY_TYPE, user.id);
 
     const userRelationships = user.locations.map(location => {
-      const parentKey = generateKey(
+      const parentKey = generateEntityKey(
         SITE_ENTITY_TYPE,
         `${user.id}_${location.buildingId}`,
       );

--- a/src/converters/UserEntityConverter.ts
+++ b/src/converters/UserEntityConverter.ts
@@ -2,13 +2,13 @@ import { User } from "../gsuite/GSuiteClient";
 import { USER_ENTITY_CLASS, USER_ENTITY_TYPE, UserEntity } from "../jupiterone";
 import toGenderProperty from "./toGenderProperty";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 import setCollectionAsFlattenFields from "../utils/setCollectionAsFlattenFields";
 
 export function createUserEntities(data: User[]): UserEntity[] {
   return data.map(user => {
     let userEntity: UserEntity = {
-      _key: generateKey(USER_ENTITY_TYPE, user.id),
+      _key: generateEntityKey(USER_ENTITY_TYPE, user.id),
       _type: USER_ENTITY_TYPE,
       _class: USER_ENTITY_CLASS,
       id: user.id,

--- a/src/converters/UserGroupRelationshipConverter.ts
+++ b/src/converters/UserGroupRelationshipConverter.ts
@@ -87,7 +87,11 @@ function findChildKey(
       return generateKey(GROUP_ENTITY_TYPE, group && group.id);
     case MemberType.USER:
       const user = findUserByEmail(users, member.email);
-      return generateKey(USER_ENTITY_TYPE, user && user.id);
+      if (user && user.id) {
+        return generateKey(USER_ENTITY_TYPE, user.id);
+      } else {
+        return null;
+      }
     default:
       return null;
   }

--- a/src/converters/UserGroupRelationshipConverter.ts
+++ b/src/converters/UserGroupRelationshipConverter.ts
@@ -8,7 +8,7 @@ import {
   UserGroupRelationship,
 } from "../jupiterone";
 
-import generateKey from "../utils/generateKey";
+import generateEntityKey from "../utils/generateEntityKey";
 
 interface UsersDict {
   [email: string]: User;
@@ -28,7 +28,7 @@ export function createUserGroupRelationships(
   });
 
   return members.reduce((acc, member) => {
-    const parentKey = generateKey(GROUP_ENTITY_TYPE, member.groupId);
+    const parentKey = generateEntityKey(GROUP_ENTITY_TYPE, member.groupId);
     const childKey = findChildKey(member, usersDict, groups);
 
     if (!childKey) {
@@ -84,11 +84,11 @@ function findChildKey(
   switch (member.memberType) {
     case MemberType.GROUP:
       const group = findGroupByEmail(groups, member.email);
-      return generateKey(GROUP_ENTITY_TYPE, group && group.id);
+      return generateEntityKey(GROUP_ENTITY_TYPE, group && group.id);
     case MemberType.USER:
       const user = findUserByEmail(users, member.email);
       if (user && user.id) {
-        return generateKey(USER_ENTITY_TYPE, user.id);
+        return generateEntityKey(USER_ENTITY_TYPE, user.id);
       } else {
         return null;
       }

--- a/src/utils/generateEntityKey.ts
+++ b/src/utils/generateEntityKey.ts
@@ -1,0 +1,15 @@
+/**
+ * Generates a valid `_key` value for entities.
+ *
+ * `_key` values must be unique within a JupiterOne account. It is important to
+ * scope the value by type to ensure this uniqueness. `id` must not be
+ * `undefined` to avoid duplicate values, such as `provider_user_undefined`.
+ *
+ * TODO: Do not accept an `undefined` id
+ *
+ * @param type entity _type
+ * @param id an identifier known to the provider
+ */
+export default function generateEntityKey(type: string, id?: string | number) {
+  return `${type}_${id}`;
+}

--- a/test/fixtures/members.json
+++ b/test/fixtures/members.json
@@ -67,6 +67,15 @@
         "role": "MEMBER",
         "type": "EXTERNAL",
         "status": "ACTIVE"
+      },
+      {
+        "kind": "admin#directory#member",
+        "etag": "\"GPUJN6YVAOElesyqxtgGs7jrFWY/UReUCuMlrvQ-aY-yW_xOk1wVI4c\"",
+        "id": "116216254206426985619",
+        "email": "example@other-gsuite-domain.com",
+        "role": "MEMBER",
+        "type": "USER",
+        "status": "ACTIVE"
       }
     ]
   },

--- a/test/utils/mockGsuiteApis.ts
+++ b/test/utils/mockGsuiteApis.ts
@@ -5,7 +5,7 @@ export interface ApiEndpoint {
 }
 
 export interface ApiEndpoints {
-  [endponitName: string]: ApiEndpoint;
+  [endpointName: string]: ApiEndpoint;
 }
 
 export function mockGsuiteApis(endpoints: ApiEndpoints) {


### PR DESCRIPTION
This will address the problem where relationship operations are generated with `_key: google_group_ABC_has_google_user_undefined`. However, this exposes a need to create mapped relationships in order to produce a valid list of group members in J1. Created https://github.com/JupiterOne/jupiter-integration-google/issues/27 to track that work.